### PR TITLE
Fix process keeps running in the background

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -192,10 +192,10 @@ impl App {
                     };
                     post_event(&sender, Event::OpenFile(file));
                 }
-                file_chooser.destroy();
             });
 
             file_chooser.run();
+            file_chooser.destroy();
         });
     }
 


### PR DESCRIPTION
The `image-roll` process keeps running in the background after I close the window. It only happens if I use the open menu. It doesn't keep running in the background if I use the command-line to open an image or if I double-click on an image.

If I move the `destroy` call out of the file choosers signal handler then the bug goes away. It makes sense that the file chooser should not be destroyed until it is completely done, but I don't know exactly what is going on.

The code could alternative be re-written to not use a signal handler at all. The `run` method "blocks" by entering a recursive main loop so the result of the call can just be used directly instead (see issue #32). Let me know if you want that instead.

Fixes issue #32.