### PR TITLE
Make feature "Set image as a wallpaper" optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 log = "0.4.14"
 env_logger = "0.9.0"
 anyhow = "1.0.52"
-ashpd = "0.2.2"
+ashpd = { version = "0.2.2", optional = true }
 
 [dev-dependencies]
 itertools = "0.10.3"
@@ -23,6 +23,10 @@ infer = "0.7.0"
 [dependencies.gtk]
 version = "0.15.3"
 features = ["v3_22_29"]
+
+[features]
+default = ["wallpaper"]
+wallpaper = ["ashpd"]  # set image as wallpaper
 
 [package.metadata.deb]
 license-file = ["LICENSE", "0"]

--- a/src/file_list.rs
+++ b/src/file_list.rs
@@ -149,6 +149,7 @@ impl FileList {
         self.current_file.as_ref().map(|(_, file)| file)
     }
 
+    #[allow(dead_code)] // currently used only with feature "wallpaper"
     pub fn current_file_uri(&self) -> Option<String> {
         self.current_file
             .as_ref()

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -4,6 +4,7 @@ use std::{
     rc::Rc,
 };
 
+#[cfg(feature = "wallpaper")]
 use ashpd::{
     desktop::wallpaper::{self, SetOn},
     WindowIdentifier,
@@ -505,6 +506,7 @@ pub fn quit(application: &gtk::Application) {
         .for_each(|window| window.close());
 }
 
+#[cfg(feature = "wallpaper")]
 pub fn set_as_wallpaper(sender: &Sender<Event>, file_list: &FileList) {
     if let Some(current_file_uri) = file_list.current_file_uri() {
         let sender = sender.clone();
@@ -525,6 +527,10 @@ pub fn set_as_wallpaper(sender: &Sender<Event>, file_list: &FileList) {
             }
         });
     }
+}
+#[cfg(not(feature = "wallpaper"))]
+pub fn set_as_wallpaper(_sender: &Sender<Event>, _file_list: &FileList) {
+    error!("This program was built without the wallpaper feature");
 }
 
 pub fn start_zoom_gesture(settings: &mut Settings) {
@@ -586,9 +592,13 @@ pub fn update_buttons_state(
     widgets.print_menu_button().set_sensitive(buttons_active);
     widgets.save_as_menu_button().set_sensitive(buttons_active);
     widgets.delete_button().set_sensitive(buttons_active);
+
+    #[cfg(feature = "wallpaper")]
     widgets
         .set_as_wallpaper_menu_button()
         .set_sensitive(buttons_active);
+    #[cfg(not(feature = "wallpaper"))]
+    widgets.set_as_wallpaper_menu_button().set_sensitive(false);
 
     widgets
         .preview_smaller_button()


### PR DESCRIPTION
This single feature depends on the `ashpd` crate which is a pretty huge
dependency - it adds 61 transitive dependencies and doubles the size of
the image-roll binary. Moreover, this feature is usable only on some
desktops. For example, Sway users will not benefit from it.

This commit introduces a (cargo) feature named "wallpaper", which is
enabled by default. When the application is built with
`--no-default-features`, the `ashpd` dependency is excluded from the
dependency tree and the "Set as wallpaper" button is disabled (by
setting `sensitive` to `false`).

This is suboptiomal, ideally I'd like to remove the button from the UI
when this feature is disabled, but I don't know how to do it without
adding too much complexity.